### PR TITLE
fix: Ensure correct sticky month is selected when scrolling upward

### DIFF
--- a/lib/src/events_months.dart
+++ b/lib/src/events_months.dart
@@ -180,15 +180,19 @@ class EventsMonthsState extends State<EventsMonths> {
                           initialMonth.month + index,
                         );
                         return InfiniteListItem(
-                          headerStateBuilder: (context, state) {
-                            WidgetsBinding.instance.addPostFrameCallback((_) {
-                              if (state.sticky && _stickyMonth != month) {
+                         headerStateBuilder: (context, state) {
+                            const stickyThreshold = 0.5;
+
+                            final isTopSticky = state.sticky && state.position < stickyThreshold;
+                            if (isTopSticky && _stickyMonth != month) {
+                              WidgetsBinding.instance.addPostFrameCallback((_) {
                                 _stickyMonth = month;
                                 widget.controller.updateFocusedDay(
                                     _stickyMonth);
                                 widget.onMonthChange?.call(_stickyMonth);
                               }
-                            });
+                              );
+                            }
                             _stickyPercent = state.position;
                             _stickyOffset = state.offset;
                             return SizedBox.shrink();


### PR DESCRIPTION
# Description
Fixes an issue where scrolling upward in the calendar view could trigger the wrong sticky month (e.g., showing the next month instead of the current one). This was caused by multiple headers being marked as `sticky: true` during transitions.

<!--
- Applied threshold-based logic to avoid incorrect month detection
-->

## Checklist

<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).

## Breaking Change?

<!--
Would your PR require CalendarView users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.

### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.