### PR TITLE
fix: Correct week iteration logic to include all months

### DIFF
--- a/lib/src/widgets/month/month.dart
+++ b/lib/src/widgets/month/month.dart
@@ -26,7 +26,7 @@ class Month extends StatelessWidget {
   Widget build(BuildContext context) {
     var startOfWeeks = <DateTime>[];
     var startOfWeek = month.startOfWeek(weekParam.startOfWeekDay);
-    while (startOfWeek.add(Duration(days: 6)).month == month.month) {
+    while (startOfWeek.add(Duration(days: 7)).month == month.month) {
       startOfWeeks.add(startOfWeek);
       startOfWeek = startOfWeek.add(Duration(days: 7));
     }


### PR DESCRIPTION
# Description
This PR updates the condition in the while loop was updated to ensure that all weeks, including those in the 11th month, are correctly iterated through and added to the `startOfWeeks` list. This fixes an issue where the 11th month was not being displayed.
